### PR TITLE
Wrong Fix!

### DIFF
--- a/src/core/p5.Renderer.js
+++ b/src/core/p5.Renderer.js
@@ -129,7 +129,7 @@ p5.Renderer.prototype.resize = function(w, h) {
 p5.Renderer.prototype.textLeading = function(l) {
   if (typeof l === 'number') {
     this._setProperty('_textLeading', l);
-    return this._pInst;
+    return this;
   }
 
   return this._textLeading;


### PR DESCRIPTION
_**p5**_::**textLeading()** should only return a **_p5_** reference when called "globally", affecting the "global" canvas:
https://p5js.org/reference/#/p5/textLeading

When called over a **_p5.Graphics_** or **_p5.Renderer_** reference, it should return itself.